### PR TITLE
Removing !importants; using dep in enqueue, instead.

### DIFF
--- a/css/useful-block-styles-editor-styles.css
+++ b/css/useful-block-styles-editor-styles.css
@@ -1,4 +1,8 @@
 /**
+ * Why all the `!important`'s? https://github.com/mrwweb/useful-block-styles/pull/5
+ */
+
+/**
  * Multicolumn List Block
  */
 .is-style-useful-multicolumn {

--- a/css/useful-block-styles.css
+++ b/css/useful-block-styles.css
@@ -1,4 +1,8 @@
 /**
+ * Why all the `!important`'s? https://github.com/mrwweb/useful-block-styles/pull/5
+ */
+
+/**
  * Multicolumn List Block
  */
 .is-style-useful-multicolumn {

--- a/useful-block-styles.php
+++ b/useful-block-styles.php
@@ -64,7 +64,7 @@ function front_end_assets() {
 	wp_enqueue_style(
 		'useful-block-styles',
 		plugin_dir_url(__FILE__) . 'css/useful-block-styles.css',
-		[],
+		['wp-block-styles'],
 		filemtime( plugin_dir_path(__FILE__) . 'css/useful-block-styles.css' ),
 	);
 


### PR DESCRIPTION
@mrwweb would this work instead for the styles? I would see that the dev might want to slightly override your styles on the front end, and battling `!important`'s would make that difficult. I think using the `dep` in the enqueue will accomplish the same thing, right?