### PR TITLE
new Screen Reader Text style for headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 ## Intentions
 
-- Provide super common block styles that you'd want on 90%+ of sites you build.
+- Provide super common block styles for text-related blocks that you'd want on 90%+ of sites you build.
 - Put this in the plugin repository for push updates to any site.
 
 ## Block Styles So Far
 
+- Heading
+	- Screen Reader Text
 - List Block
 	- No Markers
 	- Responsive Multiple Columns
@@ -25,15 +27,10 @@ All decisions up for discussion!
 ## Tested so far
 - Twenty Twenty
 - Twenty Twenty One
+- Michelle
 
 ## Other Ideas for Consideration
 
-- Group Block
-	- Grid Container
-- Columns
-	- No Gap
-	- Full-height contents
-	- Button at bottom
 - _Looking forward to more!_
 
 ## Contribution

--- a/css/useful-block-styles-editor-styles.css
+++ b/css/useful-block-styles-editor-styles.css
@@ -3,6 +3,35 @@
  */
 
 /**
+ * Screen Reader Text Headings
+ */
+.is-style-useful-screen-reader-text {
+	opacity: .6;
+	/* Center align icon with text regardless of size*/
+	display: flex;
+	align-items: center;
+}
+
+.is-style-useful-screen-reader-text::before {
+	/* ::after is used by the block editor */
+	display: inline-block;
+	width: 32px;
+	height: 32px;
+	font-size: 32px;
+	line-height: 1;
+	margin-right: 16px;
+	color: currentColor;
+	font-family: "Dashicons";
+	content: "\f530";
+}
+
+@media( min-width: 1200px ) {
+	.is-style-useful-screen-reader-text::before {
+		margin-left: -48px;
+	}
+}
+
+/**
  * Multicolumn List Block
  */
 .is-style-useful-multicolumn {

--- a/css/useful-block-styles-editor-styles.css
+++ b/css/useful-block-styles-editor-styles.css
@@ -6,27 +6,32 @@
  * Screen Reader Text Headings
  */
 .is-style-useful-screen-reader-text {
-	opacity: .6;
-	/* Center align icon with text regardless of size*/
-	display: flex;
-	align-items: center;
+	opacity: .55;
 }
 
 .is-style-useful-screen-reader-text::before {
 	/* ::after is used by the block editor */
+	float: right;
 	display: inline-block;
 	width: 32px;
 	height: 32px;
 	font-size: 32px;
 	line-height: 1;
-	margin-right: 16px;
+	margin-left: 16px;
 	color: currentColor;
 	font-family: "Dashicons";
 	content: "\f530";
 }
 
 @media( min-width: 1200px ) {
+	.is-style-useful-screen-reader-text {
+		/* Center align icon with text regardless of size*/
+		display: flex;
+		align-items: center;
+	}
 	.is-style-useful-screen-reader-text::before {
+		float: none;
+		margin-right: 16px;
 		margin-left: -48px;
 	}
 }

--- a/css/useful-block-styles-editor-styles.css
+++ b/css/useful-block-styles-editor-styles.css
@@ -6,7 +6,13 @@
  * Screen Reader Text Headings
  */
 .is-style-useful-screen-reader-text {
-	opacity: .55;
+	opacity: .5;
+	transition: opacity .15s;
+}
+
+.is-style-useful-screen-reader-text:hover,
+.is-style-useful-screen-reader-text:focus {
+	opacity: 1;
 }
 
 .is-style-useful-screen-reader-text::before {

--- a/css/useful-block-styles.css
+++ b/css/useful-block-styles.css
@@ -3,6 +3,22 @@
  */
 
 /**
+ * Screen Reader Text Heading
+ */
+.is-style-useful-screen-reader-text {
+	border: 0 !important;
+	clip: rect(1px, 1px, 1px, 1px) !important;
+	clip-path: inset(50%) !important;
+	height: 1px !important;
+	margin: -1px !important;
+	overflow: hidden !important;
+	padding: 0 !important;
+	position: absolute !important;
+	width: 1px !important;
+	word-wrap: normal !important !important;
+}
+
+/**
  * Multicolumn List Block
  */
 .is-style-useful-multicolumn {

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Useful Block Styles ===
 Contributors: mrwweb, rtvenge
-Tags: comments, spam
+Tags: Block Editor, Block Styles, Formatting, Text
 Requires at least: 5.0
 Tested up to: 5.7
 Requires PHP: 5.6
-Stable tag: 0.1.0
+Stable tag: 0.2.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/useful-block-styles.php
+++ b/useful-block-styles.php
@@ -4,7 +4,7 @@
  * Description:     A simple plugin to register Block Styles that you'd want on any site with the WordPress block editor. Includes Multicolumn and marker-less lists and Button-only File block.
  * Author:          Mark Root-Wiley (So far)
  * Text Domain:     useful-block-styles
- * Version:         0.1.0
+ * Version:         0.2.0
  *
  * @package         Useful_Block_Styles
  */

--- a/useful-block-styles.php
+++ b/useful-block-styles.php
@@ -19,6 +19,9 @@ namespace WPSea\BlockStyles;
 function get_block_styles() {
 
 	$block_styles = array(
+		'core/heading' => array(
+			'Screen Reader Text'
+		),
 		'core/list' => array(
 			'Multicolumn',
 			'No Markers',


### PR DESCRIPTION
Accessibly hides headings on front end and shows them dimmed and with icon in the editor. closes #14

## Screenshots

### Editor
![image](https://user-images.githubusercontent.com/1238696/116585743-8cdd2f80-a8cd-11eb-87ee-5723eda7baef.png)

### Front End
![image](https://user-images.githubusercontent.com/1238696/116585827-a1212c80-a8cd-11eb-9fe4-f7cb556cce9a.png)

Headings are hidden and [tota11y](https://khan.github.io/tota11y/) shows the correct outline